### PR TITLE
Add CRU4.07 and CRU4.07-1900

### DIFF
--- a/scripts/short_pams.json
+++ b/scripts/short_pams.json
@@ -30,7 +30,7 @@
         "TOTSOMC_1m": ["HWSD_M", "NCSCDV22"],        
         "FATES_GPP": ["FLUXCOM"],
         "H2OSNO": ["CanSISE"],
-        "TSA": ["CRU4.02"],
+        "TSA": ["CRU4.07", "CRU4.07-1900"],
         "RAIN": ["CMAPv1904"],
         "SNOW": ["CMAPv1904"],
         "FATES_VEGC": ["Saatchi2011", "Thurner", "NBCD2000", "Tropical"],

--- a/tests/test-data/ilamb_CLMFATES.cfg
+++ b/tests/test-data/ilamb_CLMFATES.cfg
@@ -695,10 +695,18 @@ bgcolor = "#EDEDED"
 variable = "TSA"
 alternate_vars = "tas"
 weight   = 2
-limits  = -10,30,7
+limits  = -10,30,5
 
 [CRU4.02]
 source   = "DATA/tas/CRU4.02/tas.nc"
+weight   = 25
+
+[CRU4.07]
+source   = "DATA/tas/CRU4.07/tas.nc"
+weight   = 25
+
+[CRU4.07-1900]
+source   = "DATA/tas/CRU4.07-1900/tas.nc"
 weight   = 25
 
 [FLUXNET2015]


### PR DESCRIPTION
This is points to a undated version of CRU and includes data back to 1901. As a temporary hack, I have made a folder called CRU4.07-1900 which holds a tas.nc file with only data from 1901-1920. This allows us to easily make plot obs relevant for PI simulations. This could be deleted when functionality is in place to select the right part of the observational dataset. 