### PR TITLE
Change to runoff units in  ilamb_CLMFATES.cfg

### DIFF
--- a/tests/test-data/ilamb_CLMFATES.cfg
+++ b/tests/test-data/ilamb_CLMFATES.cfg
@@ -407,7 +407,7 @@ variable       = "runoff"
 alternate_vars = "mrro,QRUNOFF"
 weight         = 5
 mass_weighting = True
-
+limits        = 0,10,7
 
 [Dai]
 ctype          = "ConfRunoff"


### PR DESCRIPTION
This moifies the units of the QRUNOFF data to correct them such that the plots are now comparable with the model outputs.

If we look in the LORA data file, the units stated there are kg/m2/s
	float mrro_bnds(time, lat, lon, nb) ;
		mrro_bnds:_FillValue = 1.e+20f ;
		mrro_bnds:units = "kg m-2 s-1" ;

which is the same as mm s-1. 

Plotting this with mm d-1 gives nonsense output. But with mm s-1 gives
<img width="3000" height="1000" alt="image" src="https://github.com/user-attachments/assets/59eec221-6259-4492-9c0d-6c6c81eb2875" />


I tried checking this against ILAMB outputs, but every one that I found was also wrongly plotted. E.g. 

https://www.ilamb.org/CMIP6/historical/HydrologyCycle/Runoff/LORA/LORA.html