### PR TITLE
Add compatibility with ipcc login node on nird

### DIFF
--- a/src/xesmf_clm_fates_diagnostic/ilamb_configurations.py
+++ b/src/xesmf_clm_fates_diagnostic/ilamb_configurations.py
@@ -86,7 +86,7 @@ def read_ilamb_configurations(cfg_file):
 
 class IlambConfigurations:
 
-    def __init__(self, cfg_file, ilamb_data_dir="/datalake/NS9560K/diagnostics/ILAMB-Data/"):
+    def __init__(self, cfg_file, ilamb_data_dir="/nird/datalake/NS9560K/diagnostics/ILAMB-Data/"):
         self.data_root = ilamb_data_dir
         if isinstance(cfg_file, dict):
             self.configurations = cfg_file


### PR DESCRIPTION
This change is needed for running the diagnostics on the ipcc login node on nird. It should not affect behavior on normal nird login nodes. 

When running on ipcc.nird.sigma2.no, remember to also add "/nird/" to the paths provided as arguments when running the code.  


