### PR TITLE
fix filename for Xu Saatchi biomass data

### DIFF
--- a/tests/test-data/ilamb_CLMFATES.cfg
+++ b/tests/test-data/ilamb_CLMFATES.cfg
@@ -32,7 +32,7 @@ plot_unit  = "kg m-2"
 space_mean = False
 
 [XuSaatchi2021]
-source     = "DATA/biomass/XuSaatchi2021/biomass_0.5x0.5.nc"
+source     = "DATA/biomass/XuSaatchi2021/XuSaatchi.nc"
 weight     = 16
 table_unit = "Pg"
 plot_unit  = "kg m-2"


### PR DESCRIPTION
The default ilamb clmfates config file has the wrong filename for the Xu Saatchi dataset so that comparison is skipped when the diagnostics package runs. This PR updates it. 