### PR TITLE
Add isoprene observations to ilamb config 

### DIFF
--- a/scripts/json_file_library/fates-sp_megan-allcompounds.json
+++ b/scripts/json_file_library/fates-sp_megan-allcompounds.json
@@ -1,0 +1,87 @@
+{
+    "VAR_LIST_MAIN" : [
+        "MEG_isoprene",
+        "MEG_pinene_a",
+        "MEG_carene_3",
+        "MEG_thujene_a",
+        "MEG_methanol",
+        "MEG_ethanol",
+        "MEG_acetic_acid",
+        "MEG_acetaldehyde",
+        "MEG_formaldehyde",
+        "TSA", 
+        "TSKIN", 
+        "U10", 
+        "FSDS",
+        "RH2M", 
+        "Q2M", 
+        "PBOT", 
+        "RAIN",
+        "SNOW",
+        "FATES_LAI",
+        "TLAI",
+        "TSOI_10CM",
+        "H2OSOI",
+        "FATES_GPP",
+        "FATES_STOMATAL_COND"
+    ],
+    "SEASONAL_VARSETS":
+    {
+        "BVOC emissions (main)": [
+            "MEG_isoprene",
+            "MEG_pinene_a",
+            "MEG_carene_3",
+            "MEG_thujene_a"
+        ],
+        "BVOC emissions (secondary)": [
+            "MEG_methanol",
+            "MEG_ethanol",
+            "MEG_acetic_acid",
+            "MEG_acetaldehyde",
+            "MEG_formaldehyde"
+        ],
+        "atm-drivers": [
+            "TSA", 
+            "TSKIN", 
+            "U10", 
+            "FSDS",
+            "RH2M", 
+            "Q2M", 
+            "PBOT", 
+            "RAIN",
+            "SNOW"
+        ],
+        "land-drivers":[
+            "FATES_LAI",
+            "TLAI",
+            "TSOI_10CM",
+            "H2OSOI",
+            "FATES_GPP",
+            "FATES_STOMATAL_COND"
+        ]
+    },
+    
+    "COMPARE_VARIABLES" : [
+            "MEG_isoprene",
+            "MEG_pinene_a",
+            "MEG_carene_3",
+            "MEG_thujene_a",
+            "TSA", 
+            "TSKIN", 
+            "U10", 
+            "RH2M", 
+            "Q2M", 
+            "PBOT", 
+            "RAIN",
+            "SNOW",
+            "FATES_LAI",
+            "TLAI",
+            "TSOI_10CM",
+            "FATES_GPP",
+            "FATES_STOMATAL_COND"
+        ],
+
+"OBSERVATION_COMPARISON" : {
+        "MEG_isoprene": ["CrIS"]
+}
+}

--- a/src/xesmf_clm_fates_diagnostic/misc_help_functions.py
+++ b/src/xesmf_clm_fates_diagnostic/misc_help_functions.py
@@ -86,6 +86,13 @@ def convert_weird_subunits(unit):
     elif "month" in unit:
         new_unit = unit.replace("month", "y")
         return new_unit, 12.
+    # TODO super hacky for MEGAN, might need fixing later
+    elif "sec" in unit:
+        new_unit = unit.replace("sec", "s")
+        return new_unit, 1
+    elif "m2" in unit:
+        new_unit = unit.replace("m2", "m^2")
+        return new_unit, 1
     return unit, 1
 
 def deal_with_weird_units_to_and_from(unit_from, unit_to):
@@ -100,15 +107,25 @@ def unit_convert_single_unit(unit_from, unit_to):
         return 1
     # TODO: This implementation assumes no exponent for nominator units
     multiplicator = 1
-    #print(f"{unit_from:}, {unit_to:}")
+    # print(f"{unit_from:}, {unit_to:}")
     unit_from, unit_to, multiplicator = deal_with_weird_units_to_and_from(unit_from, unit_to)
-    #print(f"{unit_from:}, {unit_to:}, {multiplicator}")
+    # print(f"{unit_from:}, {unit_to:}, {multiplicator}")
     if unit_from == unit_to:
         return multiplicator
     if "-" in unit_to:
         factor = -int(unit_to.split("-")[-1])
         just_string_to = unit_to.split("-")[0]
-        just_string_from = unit_from.split("-")[0]
+        if "-" in unit_from:
+            just_string_from = unit_from.split("-")[0]
+        # This is just for some weird cases in MEGAN
+        elif "^" in unit_from:
+            just_string_from = unit_from.split("^")[0]
+        else:
+            just_string_from = unit_from
+    elif "^" in unit_to:
+        factor = int(unit_to.split("^")[-1])
+        just_string_to = unit_to.split("^")[0]
+        just_string_from = unit_from.split("^")[0]  
     else:
         just_string_to = unit_to
         just_string_from = unit_from

--- a/tests/test-data/ilamb_CLMFATES.cfg
+++ b/tests/test-data/ilamb_CLMFATES.cfg
@@ -313,6 +313,19 @@ plot_unit  = "kg ha-1 yr-1"
 space_mean = False
 weight     = 16
 
+#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+[h2: Isoprene emission]
+variable       = "MEG_isoprene"
+alternate_vars = "isoprene"
+cmap           = "Greens"
+
+[CrIS]
+name = 'isoprene'
+source     = "DATA/isoprene/CrIS/global_monthly_isoprene_obs_1.27x2.5_2013_2020_kg_m2_s.nc"
+table_unit = "kg m-2 s-1" # observation units
+plot_unit  = "kg m-2 s-1"
+
 ###########################################################################
 
 [h1: Hydrology Cycle]


### PR DESCRIPTION
Related to #51 

New satellite-based observations of isoprene emissions are now available ([https://essd.copernicus.org/articles/17/7035/2025/]) for 2013-2020.

Update ilamb_CLMFATES.cfg to include the new file (converted to match the model unit (C kg/month -> kg/m2/s).