### PR TITLE
Fix to find the output path for time comparison plots

### DIFF
--- a/scripts/run_diagnostic_full_from_terminal.py
+++ b/scripts/run_diagnostic_full_from_terminal.py
@@ -165,6 +165,7 @@ if not run_dict["compare"] is None:
         run_dict['compare'],
         run_dict["compare_weight"],
         run_dict["pamfile"],
+        outdir = run_dict["outpath"],
     )
 
     diagnostic.make_combined_changeplots(diasgnostic_other, year_range_in=run_dict["year_range_compare"], ilamb_cfgs = ilamb_cfg)


### PR DESCRIPTION
My use of compare_custom_year_range didn't work until I added this fix. It wanted to default to /figs for the output directory but it didn't exist.  